### PR TITLE
Use transforms to position spheres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
+build
+tags
+*/tags
 

--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -213,8 +213,8 @@ optix::Group createScene()
 { 
   //Pre-create one geometry instance per material. 
   optix::GeometryInstance giDiffuseSphere = createUnitSphere(Lambertian(vec3f(0.5f, 0.5f, 0.5f)));
-  optix::GeometryInstance giMetalSphere = createUnitSphere(Metal(vec3f(0.7f, 0.6f, 0.5f), 0.0f));
-  optix::GeometryInstance giGlassSphere = createUnitSphere(Dielectric(1.5f));
+  //optix::GeometryInstance giMetalSphere = createUnitSphere(Metal(vec3f(0.7f, 0.6f, 0.5f), 0.0f));
+  //optix::GeometryInstance giGlassSphere = createUnitSphere(Dielectric(1.5f));
 
   //Make a geometry group for each of the geometry instances created above. 
   //Build an acceleration structure for each.
@@ -224,41 +224,41 @@ optix::Group createScene()
   ggDiffuse->setChildCount(1);
   ggDiffuse->setChild(0, giDiffuseSphere);
 
-  optix::Acceleration accMetal = g_context->createAcceleration("Bvh");
-  optix::GeometryGroup ggMetal = g_context->createGeometryGroup();
-  ggMetal->setAcceleration(accMetal);
-  ggMetal->setChildCount(1);
-  ggMetal->setChild(0, giMetalSphere);
+  //optix::Acceleration accMetal = g_context->createAcceleration("Bvh");
+  //optix::GeometryGroup ggMetal = g_context->createGeometryGroup();
+  //ggMetal->setAcceleration(accMetal);
+  //ggMetal->setChildCount(1);
+  //ggMetal->setChild(0, giMetalSphere);
 
-  optix::Acceleration accGlass = g_context->createAcceleration("Bvh");
-  optix::GeometryGroup ggGlass = g_context->createGeometryGroup();
-  ggGlass->setAcceleration(accGlass);
-  ggGlass->setChildCount(1);
-  ggGlass->setChild(0, giGlassSphere);
+  //optix::Acceleration accGlass = g_context->createAcceleration("Bvh");
+  //optix::GeometryGroup ggGlass = g_context->createGeometryGroup();
+  //ggGlass->setAcceleration(accGlass);
+  //ggGlass->setChildCount(1);
+  //ggGlass->setChild(0, giGlassSphere);
 
   //Push the transform returned by createSphereXform to t_list
   std::vector<optix::Transform> t_list;
-  t_list.push_back(createSphereXform(vec3f(0.f, -1000.0f, -1.f), 1000.f, ggDiffuse));
+  //t_list.push_back(createSphereXform(vec3f(0.f, -1000.0f, -1.f), 1000.f, ggDiffuse));
 
-  for (int a = -11; a < 11; a++) {
-    for (int b = -11; b < 11; b++) {
-      float choose_mat = rnd();
-      vec3f center(a + rnd(), 0.2f, b + rnd());
-      if (choose_mat < 0.8f) {
-        t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
-      }
-      else if (choose_mat < 0.95f) {
-        t_list.push_back(createSphereXform(center, 0.2f, ggMetal));
-      }
-      else {
-        t_list.push_back(createSphereXform(center, 0.2f, ggGlass));
-      }
-    }
-  }
+  //for (int a = -11; a < 11; a++) {
+    //for (int b = -11; b < 11; b++) {
+      //float choose_mat = rnd();
+      //vec3f center(a + rnd(), 0.2f, b + rnd());
+      //if (choose_mat < 0.8f) {
+        //t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
+      //}
+      //else if (choose_mat < 0.95f) {
+        //t_list.push_back(createSphereXform(center, 0.2f, ggMetal));
+      //}
+      //else {
+        //t_list.push_back(createSphereXform(center, 0.2f, ggGlass));
+      //}
+    //}
+  //}
 
-  t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggDiffuse));
-  t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
-  t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(0.5f, 0.0f, 0.f), 1.f, ggDiffuse));
+  //t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
+  //t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
 
   //At the end, instead of instantiating a GeometryGroup d_world, instantiate a group t_world.
   //Add children to t_world in the same way that we added children to d_world.
@@ -357,7 +357,8 @@ int main(int ac, char **av)
   const size_t Nx = 1200, Ny = 800;
 
   // create - and set - the camera
-  const vec3f lookfrom(13, 2, 3);
+  //const vec3f lookfrom(13, 2, 3);
+  const vec3f lookfrom(0, 0, -10);
   const vec3f lookat(0, 0, 0);
   Camera camera(lookfrom,
                 lookat,

--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -258,7 +258,7 @@ optix::Group createScene()
     }
   }
 
-  t_list.push_back(createSphereXform(vec3f(0.5f, 0.0f, 0.f), 1.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggDiffuse));
   t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
   t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
 
@@ -359,8 +359,8 @@ int main(int ac, char **av)
   const size_t Nx = 1200, Ny = 800;
 
   // create - and set - the camera
-  //const vec3f lookfrom(13, 2, 3);
-  const vec3f lookfrom(0, 0, -10);
+  const vec3f lookfrom(13, 2, 3);
+  //const vec3f lookfrom(0, 0, -10);
   const vec3f lookat(0, 0, 0);
   Camera camera(lookfrom,
                 lookat,

--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -148,16 +148,23 @@ optix::GeometryGroup createScene()
       }
       else if (choose_mat < 0.95f) {
         d_list.push_back(createSphere(center, 0.2f,
-                                      Metal(vec3f(0.5f*(1.0f + rnd()), 0.5f*(1.0f + rnd()), 0.5f*(1.0f + rnd())), 0.5f*rnd())));
+                                      //Metal(vec3f(0.5f*(1.0f + rnd()), 0.5f*(1.0f + rnd()), 0.5f*(1.0f + rnd())), 0.5f*rnd())));
+                                      Lambertian(vec3f(rnd()*rnd(), rnd()*rnd(), rnd()*rnd()))));
       }
       else {
-        d_list.push_back(createSphere(center, 0.2f, Dielectric(1.5f)));
+        //d_list.push_back(createSphere(center, 0.2f, Dielectric(1.5f)));
+        d_list.push_back(createSphere(center, 0.2f,
+                                      Lambertian(vec3f(rnd()*rnd(), rnd()*rnd(), rnd()*rnd()))));
       }
     }
   }
-  d_list.push_back(createSphere(vec3f(0.f, 1.f, 0.f), 1.f, Dielectric(1.5f)));
+  //d_list.push_back(createSphere(vec3f(0.f, 1.f, 0.f), 1.f, Dielectric(1.5f)));
+  //d_list.push_back(createSphere(vec3f(-4.f, 1.f, 0.f), 1.f, Lambertian(vec3f(0.4f, 0.2f, 0.1f))));
+  //d_list.push_back(createSphere(vec3f(4.f, 1.f, 0.f), 1.f, Metal(vec3f(0.7f, 0.6f, 0.5f), 0.0f)));
+
+  d_list.push_back(createSphere(vec3f(0.f, 1.f, 0.f), 1.f, Lambertian(vec3f(0.4f, 0.2f, 0.1f))));
   d_list.push_back(createSphere(vec3f(-4.f, 1.f, 0.f), 1.f, Lambertian(vec3f(0.4f, 0.2f, 0.1f))));
-  d_list.push_back(createSphere(vec3f(4.f, 1.f, 0.f), 1.f, Metal(vec3f(0.7f, 0.6f, 0.5f), 0.0f)));
+  d_list.push_back(createSphere(vec3f(4.f, 1.f, 0.f), 1.f, Lambertian(vec3f(0.7f, 0.6f, 0.5f))));
   
   // now, create the optix world that contains all these GIs
   optix::GeometryGroup d_world = g_context->createGeometryGroup();

--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -238,27 +238,29 @@ optix::Group createScene()
 
   //Push the transform returned by createSphereXform to t_list
   std::vector<optix::Transform> t_list;
-  //t_list.push_back(createSphereXform(vec3f(0.f, -1000.0f, -1.f), 1000.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(0.f, -1000.0f, -1.f), 1000.f, ggDiffuse));
 
-  //for (int a = -11; a < 11; a++) {
-    //for (int b = -11; b < 11; b++) {
-      //float choose_mat = rnd();
-      //vec3f center(a + rnd(), 0.2f, b + rnd());
-      //if (choose_mat < 0.8f) {
-        //t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
-      //}
-      //else if (choose_mat < 0.95f) {
+  for (int a = -11; a < 11; a++) {
+    for (int b = -11; b < 11; b++) {
+      float choose_mat = rnd();
+      vec3f center(a + rnd(), 0.2f, b + rnd());
+      if (choose_mat < 0.8f) {
+        t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
+      }
+      else if (choose_mat < 0.95f) {
         //t_list.push_back(createSphereXform(center, 0.2f, ggMetal));
-      //}
-      //else {
+        t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
+      }
+      else {
         //t_list.push_back(createSphereXform(center, 0.2f, ggGlass));
-      //}
-    //}
-  //}
+        t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
+      }
+    }
+  }
 
   t_list.push_back(createSphereXform(vec3f(0.5f, 0.0f, 0.f), 1.f, ggDiffuse));
-  //t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
-  //t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
 
   //At the end, instead of instantiating a GeometryGroup d_world, instantiate a group t_world.
   //Add children to t_world in the same way that we added children to d_world.

--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -248,21 +248,21 @@ optix::Group createScene()
         t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
       }
       else if (choose_mat < 0.95f) {
-        //t_list.push_back(createSphereXform(center, 0.2f, ggMetal));
-        t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
+        t_list.push_back(createSphereXform(center, 0.2f, ggMetal));
+        //t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
       }
       else {
-        //t_list.push_back(createSphereXform(center, 0.2f, ggGlass));
-        t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
+        t_list.push_back(createSphereXform(center, 0.2f, ggGlass));
+        //t_list.push_back(createSphereXform(center, 0.2f, ggDiffuse));
       }
     }
   }
 
-  //t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggGlass));
-  t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggGlass));
+  //t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggDiffuse));
   t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
-  //t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggMetal));
-  t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
+  t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggMetal));
+  //t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
 
   //At the end, instead of instantiating a GeometryGroup d_world, instantiate a group t_world.
   //Add children to t_world in the same way that we added children to d_world.

--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -213,8 +213,8 @@ optix::Group createScene()
 { 
   //Pre-create one geometry instance per material. 
   optix::GeometryInstance giDiffuseSphere = createUnitSphere(Lambertian(vec3f(0.5f, 0.5f, 0.5f)));
-  //optix::GeometryInstance giMetalSphere = createUnitSphere(Metal(vec3f(0.7f, 0.6f, 0.5f), 0.0f));
-  //optix::GeometryInstance giGlassSphere = createUnitSphere(Dielectric(1.5f));
+  optix::GeometryInstance giMetalSphere = createUnitSphere(Metal(vec3f(0.7f, 0.6f, 0.5f), 0.0f));
+  optix::GeometryInstance giGlassSphere = createUnitSphere(Dielectric(1.5f));
 
   //Make a geometry group for each of the geometry instances created above. 
   //Build an acceleration structure for each.
@@ -224,17 +224,17 @@ optix::Group createScene()
   ggDiffuse->setChildCount(1);
   ggDiffuse->setChild(0, giDiffuseSphere);
 
-  //optix::Acceleration accMetal = g_context->createAcceleration("Bvh");
-  //optix::GeometryGroup ggMetal = g_context->createGeometryGroup();
-  //ggMetal->setAcceleration(accMetal);
-  //ggMetal->setChildCount(1);
-  //ggMetal->setChild(0, giMetalSphere);
+  optix::Acceleration accMetal = g_context->createAcceleration("Bvh");
+  optix::GeometryGroup ggMetal = g_context->createGeometryGroup();
+  ggMetal->setAcceleration(accMetal);
+  ggMetal->setChildCount(1);
+  ggMetal->setChild(0, giMetalSphere);
 
-  //optix::Acceleration accGlass = g_context->createAcceleration("Bvh");
-  //optix::GeometryGroup ggGlass = g_context->createGeometryGroup();
-  //ggGlass->setAcceleration(accGlass);
-  //ggGlass->setChildCount(1);
-  //ggGlass->setChild(0, giGlassSphere);
+  optix::Acceleration accGlass = g_context->createAcceleration("Bvh");
+  optix::GeometryGroup ggGlass = g_context->createGeometryGroup();
+  ggGlass->setAcceleration(accGlass);
+  ggGlass->setChildCount(1);
+  ggGlass->setChild(0, giGlassSphere);
 
   //Push the transform returned by createSphereXform to t_list
   std::vector<optix::Transform> t_list;
@@ -258,8 +258,10 @@ optix::Group createScene()
     }
   }
 
+  //t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggGlass));
   t_list.push_back(createSphereXform(vec3f(0.f, 1.f, 0.f), 1.f, ggDiffuse));
   t_list.push_back(createSphereXform(vec3f(-4.f, 1.f, 0.f), 1.f, ggDiffuse));
+  //t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggMetal));
   t_list.push_back(createSphereXform(vec3f(4.f, 1.f, 0.f), 1.f, ggDiffuse));
 
   //At the end, instead of instantiating a GeometryGroup d_world, instantiate a group t_world.

--- a/FinalChapter_iterative/programs/dielectric.cu
+++ b/FinalChapter_iterative/programs/dielectric.cu
@@ -44,31 +44,35 @@ inline __device__ bool scatter(const optix::Ray &ray_in,
                                vec3f &scattered_direction,
                                vec3f &attenuation)
 {
+
+  float3 hit_pt_world = rtTransformPoint(RT_OBJECT_TO_WORLD, hit_rec_p);
+  float3 normal_world = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD, hit_rec_normal));
+
   vec3f outward_normal;
-  vec3f reflected = reflect(ray_in.direction, hit_rec_normal);
+  vec3f reflected = reflect(ray_in.direction, normal_world);
   float ni_over_nt;
   attenuation = vec3f(1.f, 1.f, 1.f); 
   vec3f refracted;
   float reflect_prob;
   float cosine;
   
-  if (dot(ray_in.direction, hit_rec_normal) > 0.f) {
-    outward_normal = -hit_rec_normal;
+  if (dot(ray_in.direction, normal_world) > 0.f) {
+    outward_normal = -normal_world;
     ni_over_nt = ref_idx;
-    cosine = dot(ray_in.direction, hit_rec_normal) / vec3f(ray_in.direction).length();
+    cosine = dot(ray_in.direction, normal_world) / vec3f(ray_in.direction).length();
     cosine = sqrtf(1.f - ref_idx*ref_idx*(1.f-cosine*cosine));
   }
   else {
-    outward_normal = hit_rec_normal;
+    outward_normal = normal_world;
     ni_over_nt = 1.0 / ref_idx;
-    cosine = -dot(ray_in.direction, hit_rec_normal) / vec3f(ray_in.direction).length();
+    cosine = -dot(ray_in.direction, normal_world) / vec3f(ray_in.direction).length();
   }
   if (refract(ray_in.direction, outward_normal, ni_over_nt, refracted)) 
     reflect_prob = schlick(cosine, ref_idx);
   else 
     reflect_prob = 1.f;
 
-  scattered_origin = hit_rec_p;
+  scattered_origin = hit_pt_world;
   if (rnd() < reflect_prob) 
     scattered_direction = reflected;
   else 

--- a/FinalChapter_iterative/programs/lambertian.cu
+++ b/FinalChapter_iterative/programs/lambertian.cu
@@ -46,8 +46,10 @@ inline __device__ bool scatter(const optix::Ray &ray_in,
                                vec3f &attenuation)
 {
   float3 hit_pt_world = rtTransformPoint(RT_OBJECT_TO_WORLD, hit_rec_p);
+  float3 normal_world = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD, hit_rec_normal));
+
   vec3f target
-    = hit_pt_world + hit_rec_normal + random_in_unit_sphere(rndState);
+    = hit_pt_world + normal_world + random_in_unit_sphere(rndState);
 
   // return scattering event
   scattered_origin    = hit_pt_world;
@@ -58,7 +60,9 @@ inline __device__ bool scatter(const optix::Ray &ray_in,
 
 RT_PROGRAM void closest_hit()
 {
-   prd.out.normal = hit_rec_normal;
+
+   float3 normal_world = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD, hit_rec_normal)); //debug ONLY
+   prd.out.normal = normal_world; //for debug ONLY
    prd.out.scatterEvent
     = scatter(ray,
               *prd.in.randState,

--- a/FinalChapter_iterative/programs/lambertian.cu
+++ b/FinalChapter_iterative/programs/lambertian.cu
@@ -45,12 +45,13 @@ inline __device__ bool scatter(const optix::Ray &ray_in,
                                vec3f &scattered_direction,
                                vec3f &attenuation)
 {
+  float3 hit_pt_world = rtTransformPoint(RT_OBJECT_TO_WORLD, hit_rec_p);
   vec3f target
-    = hit_rec_p + hit_rec_normal + random_in_unit_sphere(rndState);
+    = hit_pt_world + hit_rec_normal + random_in_unit_sphere(rndState);
 
   // return scattering event
-  scattered_origin    = hit_rec_p;
-  scattered_direction = (target-hit_rec_p);
+  scattered_origin    = hit_pt_world;
+  scattered_direction = (target-hit_pt_world);
   attenuation         = albedo;
   return true;
 }

--- a/FinalChapter_iterative/programs/lambertian.cu
+++ b/FinalChapter_iterative/programs/lambertian.cu
@@ -57,6 +57,7 @@ inline __device__ bool scatter(const optix::Ray &ray_in,
 
 RT_PROGRAM void closest_hit()
 {
+   prd.out.normal = hit_rec_normal;
    prd.out.scatterEvent
     = scatter(ray,
               *prd.in.randState,

--- a/FinalChapter_iterative/programs/metal.cu
+++ b/FinalChapter_iterative/programs/metal.cu
@@ -45,9 +45,12 @@ inline __device__ bool scatter(const optix::Ray &ray_in,
                                vec3f &scattered_direction,
                                vec3f &attenuation)
 {
-  float3 hrn = hit_rec_normal;
-  vec3f reflected = reflect(unit_vector(ray_in.direction),hit_rec_normal);
-  scattered_origin    = hit_rec_p;
+  float3 hit_pt_world = rtTransformPoint(RT_OBJECT_TO_WORLD, hit_rec_p);
+  float3 normal_world = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD, hit_rec_normal));
+
+  float3 hrn = normal_world;
+  vec3f reflected = reflect(unit_vector(ray_in.direction),normal_world);
+  scattered_origin    = hit_pt_world;
   scattered_direction = (reflected+fuzz*random_in_unit_sphere(rndState));
   attenuation         = vec3f(1.f);//albedo;
   return (dot(scattered_direction, hrn) > 0.f);

--- a/FinalChapter_iterative/programs/prd.h
+++ b/FinalChapter_iterative/programs/prd.h
@@ -41,5 +41,6 @@ struct PerRayData {
     vec3f        scattered_origin;
     vec3f        scattered_direction;
     vec3f        attenuation;
+    vec3f        normal; //debug only. Please remove when finished.
   } out;
 };

--- a/FinalChapter_iterative/programs/raygen.cu
+++ b/FinalChapter_iterative/programs/raygen.cu
@@ -70,6 +70,39 @@ inline __device__ vec3f missColor(const optix::Ray &ray)
   return c;
 }
 
+/*
+ *inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
+ *{
+ *  PerRayData prd;
+ *  prd.in.randState = &rnd;
+ *
+ *  vec3f attenuation = 1.f;
+ *  
+ *  //iterative version of recursion, up to depth 50 
+ *  for (int depth=0;depth<50;depth++) {
+ *    rtTrace(world, ray, prd);
+ *    if (prd.out.scatterEvent == rayDidntHitAnything)
+ *       //ray got 'lost' to the environment - 'light' it with miss
+ *       //  shader 
+ *      return attenuation * missColor(ray);
+ *
+ *    else if (prd.out.scatterEvent == rayGotCancelled)
+ *      return vec3f(0.f);
+ *
+ *    else { // ray is still alive, and got properly bounced
+ *      attenuation *= prd.out.attenuation;
+ *      ray = optix::make_Ray(prd.out.scattered_origin.as_float3(),
+ *                            prd.out.scattered_direction.as_float3(),
+ *                            0,
+ *                            1e-3f,
+ *                            RT_DEFAULT_MAX);
+ *    }
+ *  }
+ *  // recursion did not terminate - cancel it
+ *  return vec3f(0.f);
+ *}
+ */
+
 inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
 {
   PerRayData prd;
@@ -77,24 +110,12 @@ inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
 
   vec3f attenuation = 1.f;
   
-  /* iterative version of recursion, up to depth 50 */
-  for (int depth=0;depth<50;depth++) {
+  for (int depth=0;depth<1;depth++) {
     rtTrace(world, ray, prd);
-    if (prd.out.scatterEvent == rayDidntHitAnything)
-      /* ray got 'lost' to the environment - 'light' it with miss
-         shader */
-      return attenuation * missColor(ray);
-
-    else if (prd.out.scatterEvent == rayGotCancelled)
+    if (prd.out.scatterEvent == rayDidntHitAnything || prd.out.scatterEvent == rayGotCancelled) {
       return vec3f(0.f);
-
-    else { // ray is still alive, and got properly bounced
-      attenuation *= prd.out.attenuation;
-      ray = optix::make_Ray(/* origin   : */ prd.out.scattered_origin.as_float3(),
-                            /* direction: */ prd.out.scattered_direction.as_float3(),
-                            /* ray type : */ 0,
-                            /* tmin     : */ 1e-3f,
-                            /* tmax     : */ RT_DEFAULT_MAX);
+    } else { // ray is still alive
+      return 0.5f*prd.out.normal + 0.5f;
     }
   }
   // recursion did not terminate - cancel it

--- a/FinalChapter_iterative/programs/raygen.cu
+++ b/FinalChapter_iterative/programs/raygen.cu
@@ -70,6 +70,38 @@ inline __device__ vec3f missColor(const optix::Ray &ray)
   return c;
 }
 
+inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
+{
+  PerRayData prd;
+  prd.in.randState = &rnd;
+
+  vec3f attenuation = 1.f;
+  
+  //iterative version of recursion, up to depth 50 
+  for (int depth=0;depth<50;depth++) {
+    rtTrace(world, ray, prd);
+    if (prd.out.scatterEvent == rayDidntHitAnything)
+       //ray got 'lost' to the environment - 'light' it with miss
+       //  shader 
+      return attenuation * missColor(ray);
+
+    else if (prd.out.scatterEvent == rayGotCancelled)
+      return vec3f(0.f);
+
+    else { // ray is still alive, and got properly bounced
+      attenuation *= prd.out.attenuation;
+      ray = optix::make_Ray(prd.out.scattered_origin.as_float3(),
+                            prd.out.scattered_direction.as_float3(),
+                            0,
+                            1e-3f,
+                            RT_DEFAULT_MAX);
+    }
+  }
+  // recursion did not terminate - cancel it
+  return vec3f(0.f);
+}
+
+//Below is a debug version of color() that spits out the normal.
 /*
  *inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
  *{
@@ -78,49 +110,18 @@ inline __device__ vec3f missColor(const optix::Ray &ray)
  *
  *  vec3f attenuation = 1.f;
  *  
- *  //iterative version of recursion, up to depth 50 
- *  for (int depth=0;depth<50;depth++) {
+ *  for (int depth=0;depth<1;depth++) {
  *    rtTrace(world, ray, prd);
- *    if (prd.out.scatterEvent == rayDidntHitAnything)
- *       //ray got 'lost' to the environment - 'light' it with miss
- *       //  shader 
- *      return attenuation * missColor(ray);
- *
- *    else if (prd.out.scatterEvent == rayGotCancelled)
+ *    if (prd.out.scatterEvent == rayDidntHitAnything || prd.out.scatterEvent == rayGotCancelled) {
  *      return vec3f(0.f);
- *
- *    else { // ray is still alive, and got properly bounced
- *      attenuation *= prd.out.attenuation;
- *      ray = optix::make_Ray(prd.out.scattered_origin.as_float3(),
- *                            prd.out.scattered_direction.as_float3(),
- *                            0,
- *                            1e-3f,
- *                            RT_DEFAULT_MAX);
+ *    } else { // ray is still alive
+ *      return 0.5f*prd.out.normal + 0.5f;
  *    }
  *  }
  *  // recursion did not terminate - cancel it
  *  return vec3f(0.f);
  *}
  */
-
-inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
-{
-  PerRayData prd;
-  prd.in.randState = &rnd;
-
-  vec3f attenuation = 1.f;
-  
-  for (int depth=0;depth<1;depth++) {
-    rtTrace(world, ray, prd);
-    if (prd.out.scatterEvent == rayDidntHitAnything || prd.out.scatterEvent == rayGotCancelled) {
-      return vec3f(0.f);
-    } else { // ray is still alive
-      return 0.5f*prd.out.normal + 0.5f;
-    }
-  }
-  // recursion did not terminate - cancel it
-  return vec3f(0.f);
-}
 
 /*! the actual ray generation program - note this has no formal
   function parameters, but gets its paramters throught the 'pixelID'

--- a/FinalChapter_iterative/programs/sphere.cu
+++ b/FinalChapter_iterative/programs/sphere.cu
@@ -52,7 +52,8 @@ RT_PROGRAM void hit_sphere(int pid)
   if (temp < ray.tmax && temp > ray.tmin) {
     if (rtPotentialIntersection(temp)) {
       hit_rec_p = ray.origin + temp * ray.direction;
-      hit_rec_normal = (hit_rec_p - center) / radius;
+      /*hit_rec_normal = (hit_rec_p - center) / radius;*/
+      hit_rec_normal = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD,(hit_rec_p - center) / radius));
       rtReportIntersection(0);
     }
   }
@@ -60,7 +61,8 @@ RT_PROGRAM void hit_sphere(int pid)
   if (temp < ray.tmax && temp > ray.tmin) {
     if (rtPotentialIntersection(temp)) {
       hit_rec_p = ray.origin + temp * ray.direction;
-      hit_rec_normal = (hit_rec_p - center) / radius;
+      /*hit_rec_normal = (hit_rec_p - center) / radius;*/
+      hit_rec_normal = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD,(hit_rec_p - center) / radius));
       rtReportIntersection(0);
     }
   }


### PR DESCRIPTION
Position sphere using transforms rather than by using input to the sphere primitive. Now I assume that spheres, in object space, have unit radius and are centered at the origin. Colors per sphere currently do not work, and it isn't trivial to fix due to the way OptiX is currently designed. I discussed several solutions with Ingo today.