### PR TITLE
Fixed sphere rendering and added data preprocess script

### DIFF
--- a/FinalChapter_iterative/finalChapter.cpp
+++ b/FinalChapter_iterative/finalChapter.cpp
@@ -185,6 +185,10 @@ optix::Transform createSphereXform(const vec3f &center, const optix::Matrix3x3& 
     radius*upperLeft[6], radius*upperLeft[7], radius*upperLeft[8], center.z,
     0.0f,   0.0f,   0.0f,   1.0f                                 
   };                                                              
+
+  //printf("%f %f %f\n%f %f %f\n%f %f %f\n",sphereMatRaw[0],sphereMatRaw[1],sphereMatRaw[2],sphereMatRaw[4],sphereMatRaw[5],sphereMatRaw[6],sphereMatRaw[8],sphereMatRaw[9],sphereMatRaw[10]);
+  //printf("Center: %f %f %f\n", center.x, center.y, center.z);
+
   optix::Matrix4x4 matrixSphere(sphereMatRaw);   
   optix::Transform trSphere = g_context->createTransform();
   trSphere->setMatrix(false, matrixSphere.getData(),
@@ -448,12 +452,18 @@ int main(int argc, char **argv)
   YAML::Node up_dir = config["camera"]["up"];
   assert(up_dir.IsSequence());
   const vec3f up(up_dir[0].as<float>(), up_dir[1].as<float>(), up_dir[2].as<float>());
+  
+  YAML::Node light_dir_node = config["light_dir"];
+  assert(light_dir_node.IsSequence());
+  vec3f light_dir(light_dir_node[0].as<float>(), light_dir_node[1].as<float>(), light_dir_node[2].as<float>());
+  light_dir = light_dir/light_dir.length(); //normalize
 
   const std::string data_file = config["data_file"].as<std::string>();
 
   std::cout << "Camera position: " << lookfrom.x << " " << lookfrom.y << " " << lookfrom.z << " " << std::endl;
   std::cout << "Lookat position:" << lookat.x << " " << lookat.y << " " << lookat.z << " " << std::endl;
   std::cout << "Up direction:" << up.x << " " << up.y << " " << up.z << " " << std::endl;
+  std::cout << "Light dir:" << light_dir.x << " " << light_dir.y << " " << light_dir.z << " " << std::endl;
   std::cout << "Field of view (y), degrees: " << fovy << std::endl;
   std::cout << "Aperture: " << aperture << std::endl;
   std::cout << "Dist to focus: " << dist_to_focus << std::endl;
@@ -486,6 +496,8 @@ int main(int argc, char **argv)
   if(render_algo == Algo::whitted){
     std::cout << "DoF disabled because we are using Whitted-style raytracing. 'aperture' has no effect!" << std::endl;
   }
+
+  g_context["light_dir"]->set3fv(&light_dir.x);
 
   // set the ray generation and miss shader program
   setRayGenProgram();

--- a/FinalChapter_iterative/programs/raygen.cu
+++ b/FinalChapter_iterative/programs/raygen.cu
@@ -43,6 +43,8 @@ rtDeclareVariable(float3, camera_u, , );
 rtDeclareVariable(float3, camera_v, , );
 rtDeclareVariable(float, camera_lens_radius, , );
 
+rtDeclareVariable(float3, light_dir, , );
+
 struct Camera {
   static __device__ optix::Ray generateRay(float s, float t, DRand48 &rnd) 
   {
@@ -89,8 +91,7 @@ inline __device__ vec3f color(optix::Ray &ray, DRand48 &rnd)
       return vec3f(0.f);
 
     else if (prd.out.scatterEvent == rayHitWhittedDiffuse ){
-      vec3f lightDir = 1.f; //HACK. 
-      float dotProd = optix::clamp(dot(lightDir, prd.out.normal),0.0f,1.0f);
+      float dotProd = optix::clamp(dot(-light_dir, prd.out.normal),0.0f,1.0f);
       return prd.out.attenuation * dotProd; 
     } else { // ray is still alive, and got properly bounced
       attenuation *= prd.out.attenuation;

--- a/FinalChapter_iterative/programs/sphere.cu
+++ b/FinalChapter_iterative/programs/sphere.cu
@@ -40,6 +40,9 @@ rtDeclareVariable(PerRayData, prd, rtPayload, );
 // the reference code used.
 RT_PROGRAM void hit_sphere(int pid)
 {
+  // See Ch. 7: Precision Improvements for Ray/Sphere Intersection
+  // p.87 of Ray Tracing Gems, edited by Eric Haines and Tomas Akenine-Moller, Apress 2019.
+  // http://www.realtimerendering.com/raytracinggems/
   const float3 d = ray.direction;
   const float3 f = ray.origin - center; //TODO: center assumed to be zero, we can simplify this
   const float  a = dot(d, d);
@@ -70,33 +73,6 @@ RT_PROGRAM void hit_sphere(int pid)
       rtReportIntersection(0);
     }
   }
-
-/*
- *  const float3 oc = ray.origin - center;
- *  const float  a = dot(ray.direction, ray.direction);
- *  const float  b = dot(oc, ray.direction);
- *  const float  c = dot(oc, oc) - radius * radius;
- *  const float  discriminant = b * b - a * c;
- *  
- *  if (discriminant < 0.f) return;
- *
- *  float temp = (-b - sqrtf(discriminant)) / a;
- *  if (temp < ray.tmax && temp > ray.tmin) {
- *    if (rtPotentialIntersection(temp)) {
- *      hit_rec_p = ray.origin + temp * ray.direction;
- *      hit_rec_normal = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD,(hit_rec_p - center) / radius));
- *      rtReportIntersection(0);
- *    }
- *  }
- *  temp = (-b + sqrtf(discriminant)) / a;
- *  if (temp < ray.tmax && temp > ray.tmin) {
- *    if (rtPotentialIntersection(temp)) {
- *      hit_rec_p = ray.origin + temp * ray.direction;
- *      hit_rec_normal = optix::normalize(rtTransformNormal(RT_OBJECT_TO_WORLD,(hit_rec_p - center) / radius));
- *      rtReportIntersection(0);
- *    }
- *  }
- */
 }
 
 /*! returns the bounding box of the pid'th primitive

--- a/mechanical_part.yaml
+++ b/mechanical_part.yaml
@@ -5,5 +5,7 @@ camera:
   up: [0.6437328837528422, -0.7215645820362587, -0.2548578590628296]
   aperture: 0.01
   dist_to_focus: 1.0 
-data_file: "../tensor.csv" #Path relative to executable
+#data_file: "../tensor.csv" #Path relative to executable
+data_file: "../processed_tensor.csv" 
 data_scale: 0.00031858246990541144 #to match my ParaView setup
+light_dir: [-0.7582404650616285, -0.5564499244157213, -0.33975708787435704]

--- a/process_tensors.jl
+++ b/process_tensors.jl
@@ -1,12 +1,67 @@
-if size(ARGS,1) != 1
-  println("Usage: julia process_tensors.jl <filename>.csv");
+if size(ARGS,1) != 2
+  println("Usage: julia process_tensors.jl <input_filename> <output_filename>");
+  println("Assumes that input is a CSV file.");
   exit();
 end
 
 using DataFrames;
+using LinearAlgebra;
+using Printf;
 
-tensor_df = readtable(ARGS[1]);
-for i in 1:size(tensor_df,1) 
-  curr_row = tensor_df[i,:]
-  println(curr_row)
+#mutates out_Q and out_D_modified
+function get_tensor_warp!(T, e_min, e_max, out_Q, out_D_modified)
+  S = (T + T')/2; #S is the symmetric part of T
+  eigenDecomp = eigen(S);
+  out_Q[:] = eigenDecomp.vectors;
+
+
+  #println(det(out_Q));
+  #for lambda in eigenDecomp.values
+  #    if abs(lambda) < TOL # reject values too close to zero
+  #        return false;
+  #    end
+  #end
+
+  modified_eigvals = abs.(eigenDecomp.values) 
+  modified_eigvals = clamp.(modified_eigvals, e_min, e_max);
+
+  out_D_modified[:] = Diagonal(modified_eigvals)
+  return true;
 end
+
+# in_file: input CSV file
+# out_file: CSV file with Q*D_clamped as the 3x3 matrix
+# min_lambda: lower bound for eigenvalue (after taking absolute value) 
+# max_lambda: upper bound for eigenvalue (after taking absolute value) 
+function process_tensors(in_file, out_file, min_lambda, max_lambda)
+  tensor_df = readtable(in_file);
+  out_handle = open(out_file, "w");
+
+  for i in 1:size(tensor_df,1)
+    curr_row = tensor_df[i,1:9];
+    T_flat = [x for x in curr_row];
+    T = transpose(reshape(T_flat, 3, 3))
+
+    Q = Array{Float64,2}(undef, 3,3);
+    fill!(Q,NaN);
+    D_clamped = Array{Float64,2}(undef, 3,3);
+    fill!(D_clamped,NaN);
+    valid = get_tensor_warp!(T, min_lambda, max_lambda, Q, D_clamped);
+
+    if !valid
+      continue;
+    end
+
+    #take a transpose here because Julia operates
+    #in row major order
+    A = transpose(Q*D_clamped); 
+    #println(tensor_df[i,10]);
+    out_s = @sprintf "%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f\n" A[1] A[2] A[3] A[4] A[5] A[6] A[7] A[8] A[9] tensor_df[i,10] tensor_df[i,11] tensor_df[i,12] ;       
+    write(out_handle, out_s)
+    #print(out_s);
+  end
+
+  close(out_handle);
+end
+
+process_tensors(ARGS[1], ARGS[2], 5e-2, Inf)

--- a/sphere_test.yaml
+++ b/sphere_test.yaml
@@ -7,3 +7,4 @@ camera:
   dist_to_focus: 4.0 
 data_file: "../single_sphere.csv" #Path relative to executable
 data_scale: 1.0 
+light_dir: [0.0, 0.0, -1.0]


### PR DESCRIPTION
1. Sphere rendering is fixed.
2. I added a data preprocessing script. The script flips eigenvalues if they are negative, and clamps eigenvalues too close to zero to small, nonzero values. To run the script, please execute: `julia process_tensors.jl <original_data>.csv <processed_data>.csv`. Right now mechanical_part.yaml is pointing to `processed_tensor.csv`, which is `tensor.csv` but run through my script. 

P.S. This is a [Julia](https://julialang.org/) script. I already made sure that Julia was installed on the development machine. 